### PR TITLE
fix: image is missing in output

### DIFF
--- a/_build/Frontmatter.sc
+++ b/_build/Frontmatter.sc
@@ -19,6 +19,7 @@ case class FrontMatter(
       val builder = Map.newBuilder[String, Any]
       builder += "title" -> title
       builder += "author" -> author
+      builder += "image" -> image.getOrElse("")
       date.foreach(d => builder += "date" -> d.toString)
       builder += "ingress" -> ingress.map(_.replaceAll("\n", " ")).getOrElse("")
       builder += "labels" -> labels.getOrElse(Seq.empty).asJava


### PR DESCRIPTION
When creating a new post with the swing gui (NewArticle.sc) the image selected is not added to the markdown post. The fix is to add a missing part to the toYaml function.