### PR TITLE
fix: hide menu on click

### DIFF
--- a/_project/src/main/scala/net/scalytica/blaargh/components/Navbar.scala
+++ b/_project/src/main/scala/net/scalytica/blaargh/components/Navbar.scala
@@ -79,7 +79,11 @@ object Navbar {
       val isActive = props.currPage == menuItem || (menuItem == Home && props.currPage.isInstanceOf[Posts])
 
       <.li(Styles.blaarghNavItem(isActive),
-        <.a(Styles.blaarghNavbarLink, ^.href := "_", ^.onClick ==> { (e: ReactEventI) => e.preventDefaultCB >> props.ctl.set(menuItem) },
+        <.a(Styles.blaarghNavbarLink,
+          "data-toggle".reactAttr := "collapse",
+          "data-target".reactAttr := "#collapseNav",
+          ^.href := "_",
+          ^.onClick ==> { (e: ReactEventI) => e.preventDefaultCB >> props.ctl.set(menuItem) },
           <.span(menuName),
           if (isActive) <.span(Styles.navActiveHamburger, "(current)") else EmptyTag
         )


### PR DESCRIPTION
Using bootstrap standard method for hiding menu. Actually the same way as the button for opening and closing the menu ;)